### PR TITLE
Add AWS S3 and Google GCS virtual filesystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ A working SSH agent.
 I have only tested this on Linux & OSX.
 
 # Configuration
-Configuration is divided into three sections: `server`, `auth`, and `ssh`.
+Configuration is divided into different sections: `server`, `auth`, `ssh`, and `aws`.
 
 ### server
 - `use_tls` : boolean. If set `tls_key` and `tls_cert` are required.
@@ -110,10 +110,19 @@ Example:
 Supported options:
 
 ### ssh
-- `signing_key`: string. Path to the signing ssh private key you created earlier.
+- `signing_key`: string. Path to the signing ssh private key you created earlier. This can be a S3 or GCS path using `/s3/<bucket>/<path/to/key>` or `/gcs/<bucket>/<path/to/key>` as appropriate. For S3 you should add an [aws](#aws) config as needed.
 - `additional_principals`: array of string. By default certificates will have one principal set - the username portion of the requester's email address. If `additional_principals` is set, these will be added to the certificate e.g. if your production machines use shared user accounts.
 - `max_age`: string. If set the server will not issue certificates with an expiration value longer than this, regardless of what the client requests. Must be a valid Go [`time.Duration`](https://golang.org/pkg/time/#ParseDuration) string.
 - `permissions`: array of string. Actions the certificate can perform. See the [`-O` option to `ssh-keygen(1)`](http://man.openbsd.org/OpenBSD-current/man1/ssh-keygen.1) for a complete list.
+
+### aws
+AWS configuration is only needed for accessing signing keys stored on S3, and isn't required even then.
+The S3 client can be configured using any of [the usual AWS-SDK means](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk) - environment variables, IAM roles etc.
+It's strongly recommended that signing keys stored on S3 be locked down to specific IAM roles and encrypted using KMS.
+
+- `region`: string. AWS region the bucket resides in, e.g. `us-east-1`.
+- `access_key`: string. AWS Access Key ID.
+- `secret_key`: string. AWS Secret Key.
 
 ## Configuring ssh
 The client needs no special configuration, just a running ssh-agent.

--- a/cmd/cashierd/main.go
+++ b/cmd/cashierd/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nsheridan/cashier/server/auth/github"
 	"github.com/nsheridan/cashier/server/auth/google"
 	"github.com/nsheridan/cashier/server/config"
+	"github.com/nsheridan/cashier/server/fs"
 	"github.com/nsheridan/cashier/server/signer"
 	"github.com/nsheridan/cashier/templates"
 )
@@ -199,6 +200,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	fs.Register(&config.AWS)
 	signer, err := signer.New(config.SSH)
 	if err != nil {
 		log.Fatal(err)

--- a/example-server.conf
+++ b/example-server.conf
@@ -1,3 +1,4 @@
+# Server config
 server {
   use_tls = true  # Optional. If this is set then `tls_key` and `tls_cert` must be set
   tls_key = "server.key"  # Path to TLS key
@@ -6,6 +7,7 @@ server {
   cookie_secret = "supersecret"  # Authentication key for the client cookie
 }
 
+# Oauth2 configuration
 auth {
   provider = "google"  # Oauth provider to use
   oauth_client_id = "nnnnnnnnnnnnnnnn.apps.googleusercontent.com"  # Oauth client ID
@@ -16,9 +18,18 @@ auth {
   }
 }
 
+# Configuration for the certificate signer.
 ssh {
   signing_key = "signing_key"  # Path to the CA signing secret key
   additional_principals = ["ec2-user", "ubuntu"]  # Additional principals to allow
   max_age = "720h"  # Maximum lifetime of a ssh certificate
   permissions = ["permit-pty", "permit-X11-forwarding", "permit-agent-forwarding", "permit-port-forwarding", "permit-user-rc"]  #  Permissions associated with a certificate.
+}
+
+# Optional AWS config. if an aws config is present, the signing key can be read from S3 using the syntax `/s3/bucket/path/to/signing.key`.
+# These can also be set configured using the standard aws-sdk environment variables, IAM roles etc. https://github.com/aws/aws-sdk-go/wiki/configuring-sdk
+aws {
+  region = "eu-west-1"
+  access_key = "abcdef"
+  secret_key = "xyz123"
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	Server `mapstructure:"server"`
 	Auth   `mapstructure:"auth"`
 	SSH    `mapstructure:"ssh"`
+	AWS    `mapstructure:"aws"`
 }
 
 // unmarshalled holds the raw config.
@@ -20,6 +21,7 @@ type unmarshalled struct {
 	Server []Server `mapstructure:"server"`
 	Auth   []Auth   `mapstructure:"auth"`
 	SSH    []SSH    `mapstructure:"ssh"`
+	AWS    []AWS    `mapstructure:"aws"`
 }
 
 // Server holds the configuration specific to the web server and sessions.
@@ -48,6 +50,14 @@ type SSH struct {
 	Permissions          []string `mapstructure:"permissions"`
 }
 
+// AWS holds Amazon AWS configuration.
+// AWS can also be configured using SDK methods.
+type AWS struct {
+	Region    string `mapstructure:"region"`
+	AccessKey string `mapstructure:"access_key"`
+	SecretKey string `mapstructure:"secret_key"`
+}
+
 func verifyConfig(u *unmarshalled) error {
 	var err error
 	if len(u.SSH) == 0 {
@@ -58,6 +68,10 @@ func verifyConfig(u *unmarshalled) error {
 	}
 	if len(u.Server) == 0 {
 		err = multierror.Append(errors.New("missing server config block"))
+	}
+	if len(u.AWS) == 0 {
+		// AWS config is optional
+		u.AWS = append(u.AWS, AWS{})
 	}
 	return err
 }
@@ -80,5 +94,6 @@ func ReadConfig(r io.Reader) (*Config, error) {
 		Server: u.Server[0],
 		Auth:   u.Auth[0],
 		SSH:    u.SSH[0],
+		AWS:    u.AWS[0],
 	}, nil
 }

--- a/server/fs/s3.go
+++ b/server/fs/s3.go
@@ -1,0 +1,152 @@
+package fs
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"go4.org/wkfs"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/nsheridan/cashier/server/config"
+)
+
+func Register(config *config.AWS) {
+	ac := &aws.Config{}
+	// If region is unset the SDK will attempt to read the region from the environment.
+	if config.Region != "" {
+		ac.Region = aws.String(config.Region)
+	}
+	// Attempt to get credentials from the cashier config.
+	// Otherwise check for standard credentials. If neither are present register the fs as broken.
+	// TODO: implement this as a provider.
+	if config.AccessKey != "" && config.SecretKey != "" {
+		ac.Credentials = credentials.NewStaticCredentials(config.AccessKey, config.SecretKey, "")
+	} else {
+		_, err := session.New().Config.Credentials.Get()
+		if err != nil {
+			registerBrokenFS(errors.New("aws credentials not found"))
+			return
+		}
+	}
+	sc := s3.New(session.New(ac))
+	if aws.StringValue(sc.Config.Region) == "" {
+		registerBrokenFS(errors.New("aws region configuration not found"))
+		return
+	}
+	wkfs.RegisterFS("/s3/", &s3FS{
+		sc: sc,
+	})
+}
+
+func registerBrokenFS(err error) {
+	wkfs.RegisterFS("/s3/", &s3FS{
+		err: err,
+	})
+}
+
+type s3FS struct {
+	sc  *s3.S3
+	err error
+}
+
+func (fs *s3FS) parseName(name string) (bucket, fileName string, err error) {
+	if fs.err != nil {
+		return "", "", fs.err
+	}
+	name = strings.TrimPrefix(name, "/s3/")
+	i := strings.Index(name, "/")
+	if i < 0 {
+		return name, "", nil
+	}
+	return name[:i], name[i+1:], nil
+}
+
+// Open opens the named file for reading.
+func (fs *s3FS) Open(name string) (wkfs.File, error) {
+	bucket, fileName, err := fs.parseName(name)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := fs.sc.GetObject(&s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &fileName,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer obj.Body.Close()
+	slurp, err := ioutil.ReadAll(obj.Body)
+	if err != nil {
+		return nil, err
+	}
+	return &file{
+		name:   name,
+		Reader: bytes.NewReader(slurp),
+	}, nil
+}
+
+func (fs *s3FS) Stat(name string) (os.FileInfo, error) { return fs.Lstat(name) }
+func (fs *s3FS) Lstat(name string) (os.FileInfo, error) {
+	bucket, fileName, err := fs.parseName(name)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := fs.sc.GetObject(&s3.GetObjectInput{
+		Bucket: &bucket,
+		Key:    &fileName,
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NoSuchKey" {
+				return nil, os.ErrNotExist
+			}
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &statInfo{
+		name: path.Base(fileName),
+		size: *obj.ContentLength,
+	}, nil
+}
+
+func (fs *s3FS) MkdirAll(path string, perm os.FileMode) error { return nil }
+
+func (fs *s3FS) OpenFile(name string, flag int, perm os.FileMode) (wkfs.FileWriter, error) {
+	return nil, errors.New("not implemented")
+}
+
+type statInfo struct {
+	name    string
+	size    int64
+	isDir   bool
+	modtime time.Time
+}
+
+func (si *statInfo) IsDir() bool        { return si.isDir }
+func (si *statInfo) ModTime() time.Time { return si.modtime }
+func (si *statInfo) Mode() os.FileMode  { return 0644 }
+func (si *statInfo) Name() string       { return path.Base(si.name) }
+func (si *statInfo) Size() int64        { return si.size }
+func (si *statInfo) Sys() interface{}   { return nil }
+
+type file struct {
+	name string
+	*bytes.Reader
+}
+
+func (*file) Close() error   { return nil }
+func (f *file) Name() string { return path.Base(f.name) }
+func (f *file) Stat() (os.FileInfo, error) {
+	panic("Stat not implemented on /s3/ files yet")
+}

--- a/server/signer/signer.go
+++ b/server/signer/signer.go
@@ -4,10 +4,12 @@ import (
 	"crypto/md5"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"strings"
 	"time"
+
+	"go4.org/wkfs"
+	_ "go4.org/wkfs/gcs" // Register "/gcs/" as a wkfs.
 
 	"github.com/nsheridan/cashier/lib"
 	"github.com/nsheridan/cashier/server/config"
@@ -71,7 +73,7 @@ func makeperms(perms []string) map[string]string {
 
 // New creates a new KeySigner from the supplied configuration.
 func New(conf config.SSH) (*KeySigner, error) {
-	data, err := ioutil.ReadFile(conf.SigningKey)
+	data, err := wkfs.ReadFile(conf.SigningKey)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read CA key %s: %v", conf.SigningKey, err)
 	}


### PR DESCRIPTION
This allows the signing key to be read directly from S3 or GCS using a path like `/s3/<bucket>/<path/to/signing.key>` or `/gcs/<bucket>/<path/to/signing.key>`