### PR TITLE
Update whitelisting

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Configuration is divided into different sections: `server`, `auth`, `ssh`, and `
 - `oauth_client_secret` : string. Oauth secret.
 - `oauth_callback_url` : string. URL that the Oauth provider will redirect to after user authorisation. The path is hardcoded to `"/auth/callback"` in the source.
 - `provider_opts` : object. Additional options for the provider.
-- `users_whitelist` : array of strings. Optional list of whitelisted usernames. If missing, all users of your current domain/organization are allowed to authenticate against cashierd.
+- `users_whitelist` : array of strings. Optional list of whitelisted usernames. If missing, all users of your current domain/organization are allowed to authenticate against cashierd. For Google auth a user is an email address. For GitHub auth a user is a GitHub username.
 
 #### Provider-specific options
 

--- a/server/auth/github/github.go
+++ b/server/auth/github/github.go
@@ -62,11 +62,16 @@ func (c *Config) Name() string {
 
 // Valid validates the oauth token.
 func (c *Config) Valid(token *oauth2.Token) bool {
-	if len(c.whitelist) == 0 && !c.whitelist[c.Username(token)] {
+	if len(c.whitelist) > 0 && !c.whitelist[c.Username(token)] {
 		return false
 	}
 	if !token.Valid() {
 		return false
+	}
+	if c.organization == "" {
+		// There's no organization and the token is valid. Can only reach here
+		// if there's a user whitelist set and the user is in the whitelist.
+		return true
 	}
 	client := githubapi.NewClient(c.newClient(token))
 	member, _, err := client.Organizations.IsMember(c.organization, c.Username(token))


### PR DESCRIPTION
Whitelist Google users based on their email address instead of the username part of the email address.
Plain gmail (non Google Apps) accounts don't necessarily end in '@gmail.com', and whitelisting on username alone is open to abuse.
Skip testing for a Google Apps domain (ui.Hd) if no domain is configured.
Principals will still be added as the user part of the email address.

For the Github provider, skip checking that the user is a member of an organization is none is configured.