### PR TITLE
Load private key in memory as well

### DIFF
--- a/cmd/cashier/client_test.go
+++ b/cmd/cashier/client_test.go
@@ -40,8 +40,8 @@ func TestLoadCert(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error reading from agent: %v", err)
 	}
-	if len(listedKeys) != 1 {
-		t.Fatalf("Expected 1 key, got %d", len(listedKeys))
+	if len(listedKeys) != 2 {
+		t.Fatalf("Expected 2 keys, got %d", len(listedKeys))
 	}
 	if !bytes.Equal(listedKeys[0].Marshal(), c.Marshal()) {
 		t.Fatal("Certs not equal")

--- a/cmd/cashier/main.go
+++ b/cmd/cashier/main.go
@@ -42,6 +42,14 @@ func installCert(a agent.Agent, cert *ssh.Certificate, key key) error {
 	if err := a.Add(pubcert); err != nil {
 		return fmt.Errorf("error importing certificate: %s", err)
 	}
+	privkey := agent.AddedKey{
+		PrivateKey:   key,
+		Comment:      cert.KeyId,
+		LifetimeSecs: uint32(lifetime),
+	}
+	if err := a.Add(privkey); err != nil {
+		return fmt.Errorf("error importing key: %s", err)
+	}
 	return nil
 }
 
@@ -147,5 +155,5 @@ func main() {
 	if err := installCert(a, cert, priv); err != nil {
 		log.Fatalln(err)
 	}
-	fmt.Println("Certificate added.")
+	fmt.Println("Credentials added.")
 }


### PR DESCRIPTION
OpenBSD OpenSSH 7.2 suffers from this bug: https://bugzilla.mindrot.org/show_bug.cgi?id=2550
If the certificate has a private key inside it then ssh will ignore the entry, looking for the private bits outside the certificate.

This PR explicitly loads the private key inside ssh-agent, next to the cert. I've used the same comment as the certificate when loading the key so it is easier to figure out which key belongs to which certificate.