### PR TITLE
Simplify key generation

### DIFF
--- a/client/keys_test.go
+++ b/client/keys_test.go
@@ -1,28 +1,40 @@
 package client
 
 import (
+	"crypto/rsa"
 	"reflect"
 	"testing"
 )
 
 func TestGenerateKeys(t *testing.T) {
 	var tests = []struct {
-		key  string
-		size int
+		opts KeyOptions
 		want string
 	}{
-		{"ecdsa", 256, "*ecdsa.PrivateKey"},
-		{"rsa", 1024, "*rsa.PrivateKey"},
-		{"ed25519", 256, "*ed25519.PrivateKey"},
+		{KeyOptions{"ecdsa", 256}, "*ecdsa.PrivateKey"},
+		{KeyOptions{Type: "ecdsa"}, "*ecdsa.PrivateKey"},
+		{KeyOptions{"rsa", 1024}, "*rsa.PrivateKey"},
+		{KeyOptions{Type: "ed25519"}, "*ed25519.PrivateKey"},
 	}
 
 	for _, tst := range tests {
-		k, _, err := GenerateKey(tst.key, tst.size)
+		k, _, err := GenerateKey(tst.opts)
 		if err != nil {
 			t.Error(err)
 		}
 		if reflect.TypeOf(k).String() != tst.want {
 			t.Errorf("Wrong key type returned. Got %T, wanted %s", k, tst.want)
 		}
+	}
+}
+
+func TestDefaultOptions(t *testing.T) {
+	k, _, err := GenerateKey()
+	if err != nil {
+		t.Error(err)
+	}
+	_, ok := k.(*rsa.PrivateKey)
+	if !ok {
+		t.Errorf("Unexpected key type %T, wanted *rsa.PrivateKey", k)
 	}
 }

--- a/cmd/cashier/main.go
+++ b/cmd/cashier/main.go
@@ -36,7 +36,7 @@ func main() {
 		fmt.Println("Error launching web browser. Go to the link in your web browser")
 	}
 	fmt.Println("Generating new key pair")
-	priv, pub, err := client.GenerateKey(c.Keytype, c.Keysize)
+	priv, pub, err := client.GenerateKey(client.KeyOptions{c.Keytype, c.Keysize})
 	if err != nil {
 		log.Fatalln("Error generating key pair: ", err)
 	}


### PR DESCRIPTION
Use an options struct to hold key generation options.
Make it entirely optional.