### PR TITLE
Add a public_file_prefix option to cashier.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@ config.json
 cashierd.conf
 tmp
 
-cashier
-cashierd
+/cashier
+/cashierd
 
 signing_key
 http.log

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ server {
 }
 ```
 
-Prior to using MySQL, MongoDB or SQLite you need to create the database and tables using [one of the provided files](db).  
-e.g. `mysql < db/seed.sql` or `mongo db/seed.js`.  
+Prior to using MySQL, MongoDB or SQLite you need to create the database and tables using [one of the provided files](db).
+e.g. `mysql < db/seed.sql` or `mongo db/seed.js`.
 Obviously you should setup a role user for running in prodution.
 
 ### datastore
@@ -165,9 +165,9 @@ Obviously you should setup a role user for running in prodution.
 
 ~~Supported database providers: `mysql`, `mongo`, `sqlite` and `mem`.~~
 
-~~`mem` is an in-memory database intended for testing and takes no additional config options.~~  
-~~`mysql` is the MySQL database and accepts `username`, `password` and `host` arguments. Only `username` and `host` arguments are required. `port` is assumed to be 3306 unless otherwise specified.~~  
-~~`mongo` is MongoDB and accepts `username`, `password` and `host` arguments. All arguments are optional and multiple hosts can be specified using comma-separated values: `mongo:dbuser:dbpasswd:host1,host2`.~~  
+~~`mem` is an in-memory database intended for testing and takes no additional config options.~~
+~~`mysql` is the MySQL database and accepts `username`, `password` and `host` arguments. Only `username` and `host` arguments are required. `port` is assumed to be 3306 unless otherwise specified.~~
+~~`mongo` is MongoDB and accepts `username`, `password` and `host` arguments. All arguments are optional and multiple hosts can be specified using comma-separated values: `mongo:dbuser:dbpasswd:host1,host2`.~~
 ~~`sqlite` is the SQLite database and accepts a `path` argument.~~
 
 ~~If no datastore is specified the `mem` store is used by default.~~
@@ -227,9 +227,9 @@ Supported options:
 - `permissions`: array of string. Specify the actions the certificate can perform. See the [`-O` option to `ssh-keygen(1)`](http://man.openbsd.org/OpenBSD-current/man1/ssh-keygen.1) for a complete list. e.g. `permissions = ["permit-pty", "permit-port-forwarding", force-command=/bin/ls", "source-address=192.168.0.0/24"]`
 
 ## aws
-AWS configuration is only needed for accessing signing keys stored on S3, and isn't totally necessary even then.  
-The S3 client can be configured using any of [the usual AWS-SDK means](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk) - environment variables, IAM roles etc.  
-It's strongly recommended that signing keys stored on S3 be locked down to specific IAM roles and encrypted using KMS.  
+AWS configuration is only needed for accessing signing keys stored on S3, and isn't totally necessary even then.
+The S3 client can be configured using any of [the usual AWS-SDK means](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk) - environment variables, IAM roles etc.
+It's strongly recommended that signing keys stored on S3 be locked down to specific IAM roles and encrypted using KMS.
 
 - `region`: string. AWS region the bucket resides in, e.g. `us-east-1`.
 - `access_key`: string. AWS Access Key ID. This can be a secret stored in a [vault](https://www.vaultproject.io/) using the form `/vault/path/key` e.g. `/vault/secret/cashier/aws_access_key`.
@@ -242,7 +242,7 @@ Vault support is currently a work-in-progress.
 - `token`: string. Auth token for the vault.
 
 # Usage
-Cashier comes in two parts, a [cli](cmd/cashier) and a [server](cmd/cashierd).  
+Cashier comes in two parts, a [cli](cmd/cashier) and a [server](cmd/cashierd).
 The server is configured using a HCL configuration file - [example](example-server.conf).
 
 For the server you need the following:
@@ -250,18 +250,41 @@ For the server you need the following:
 - OAuth (Google or GitHub) credentials. You may also need to set the callback URL when creating these.
 
 ## Using cashier
-Once the server is up and running you'll need to configure your client.  
-The client is configured using either a [HCL](https://github.com/hashicorp/hcl) configuration file - [example](example-client.conf) - or command-line flags.  
+Once the server is up and running you'll need to configure your client.
+The client is configured using either a [HCL](https://github.com/hashicorp/hcl) configuration file - [example](example-client.conf) - or command-line flags.
+
+- `ca`          CA server (default "http://localhost:10000").
+- `config`      Path to config file (default "/Users/kevin/.cashier.conf").
+- `key_size`    Key size. Ignored for ed25519 keys (default 2048).
+- `key_type`    Type of private key to generate - rsa, ecdsa or ed25519 (default "rsa").
+- `public_file_prefix` Prefix for filename for public key and cert (optional, no default). The public key is put in a file with `.pub` appended to it; the public cert file in a file with `-cert.pub` appended to it.
+- `validity`    Key validity (default 24h0m0s).
 
 Running the `cashier` cli tool will open a browser window at the configured CA address.
-The CA will redirect to the auth provider for authorisation, and redirect back to the CA where the access token will printed.  
-Copy the access token. In the terminal where you ran the `cashier` cli paste the token at the prompt.  
-The client will then generate a new ssh key-pair and send the public part to the server (along with the access token).  
+The CA will redirect to the auth provider for authorisation, and redirect back to the CA where the access token will printed.
+Copy the access token. In the terminal where you ran the `cashier` cli paste the token at the prompt.
+The client will then generate a new ssh key-pair and send the public part to the server (along with the access token).
 Once signed the client will install the key and signed certificate in your ssh agent. When the certificate expires it will be removed automatically from the agent.
 
+If you set `public_file_prefix` then the public key and public cert
+will be written to the files that start with `public_file_prefix`
+and end with `.pub` and `-cert.pub` respectively.
+
+In your `ssh_config` you can load these for a given host with the
+`IdentityFile` and `CertificateFile`. However prior to OpenSSH
+version 7.2p1 the latter option didn't exist. In that case you could
+specify `~/.ssh/some-identity` as your `IdentityFile` and OpenSSH
+would look in `~/.ssh/some-identity.pub` and
+`~/.ssh/some-identity-cert.pub`.
+
+Starting with 7.2p1 the two options exist in the `ssh_config` and
+you'll need to use the full paths to them. Note that like these
+`ssh_config` options, the `public_file_prefix` supports tilde
+expansion.
+
 ## Configuring SSH
-The ssh client needs no special configuration, just a running ssh-agent.  
-The ssh server needs to trust the public part of the CA signing key. Add something like the following to your sshd_config:
+The ssh client needs no special configuration, just a running `ssh-agent`.
+The ssh server needs to trust the public part of the CA signing key. Add something like the following to your `sshd_config`:
 ```
 TrustedUserCAKeys /etc/ssh/ca.pub
 ```
@@ -270,12 +293,12 @@ where `/etc/ssh/ca.pub` contains the public part of your signing key.
 If you wish to use certificate revocation you need to set the `RevokedKeys` option in sshd_config - see the next section.
 
 ## Revoking certificates
-When a certificate is signed a record is kept in the configured datastore. You can view issued certs at `http(s)://<ca url>/admin/certs` and also revoke them.  
+When a certificate is signed a record is kept in the configured datastore. You can view issued certs at `http(s)://<ca url>/admin/certs` and also revoke them.
 The revocation list is served at `http(s)://<ca url>/revoked`. To use it your sshd_config must have `RevokedKeys` set:
 ```
 RevokedKeys /etc/ssh/revoked_keys
 ```
-See the [`RevokedKeys` option in the sshd_config man page](http://man.openbsd.org/OpenBSD-current/man5/sshd_config) for more.  
+See the [`RevokedKeys` option in the sshd_config man page](http://man.openbsd.org/OpenBSD-current/man5/sshd_config) for more.
 Keeping the revoked list up to date can be done with a cron job like:
 ```
 */10 * * * * * curl -s -o /etc/ssh/revoked_keys https://sshca.example.com/revoked
@@ -288,5 +311,5 @@ Remember that the `revoked_keys` file **must** exist and **must** be readable by
 - Host certificates - only user certificates are supported at present.
 
 # Contributing
-Pull requests are welcome but forking Go repos can be a pain. [This is a good guide to forking and creating pull requests for Go projects](https://splice.com/blog/contributing-open-source-git-repositories-go/).  
+Pull requests are welcome but forking Go repos can be a pain. [This is a good guide to forking and creating pull requests for Go projects](https://splice.com/blog/contributing-open-source-git-repositories-go/).
 Dependencies are vendored with [govendor](https://github.com/kardianos/govendor).

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ server {
 }
 ```
 
-Prior to using MySQL, MongoDB or SQLite you need to create the database and tables using [one of the provided files](db).
-e.g. `mysql < db/seed.sql` or `mongo db/seed.js`.
+Prior to using MySQL, MongoDB or SQLite you need to create the database and tables using [one of the provided files](db).  
+e.g. `mysql < db/seed.sql` or `mongo db/seed.js`.  
 Obviously you should setup a role user for running in prodution.
 
 ### datastore
@@ -165,9 +165,9 @@ Obviously you should setup a role user for running in prodution.
 
 ~~Supported database providers: `mysql`, `mongo`, `sqlite` and `mem`.~~
 
-~~`mem` is an in-memory database intended for testing and takes no additional config options.~~
-~~`mysql` is the MySQL database and accepts `username`, `password` and `host` arguments. Only `username` and `host` arguments are required. `port` is assumed to be 3306 unless otherwise specified.~~
-~~`mongo` is MongoDB and accepts `username`, `password` and `host` arguments. All arguments are optional and multiple hosts can be specified using comma-separated values: `mongo:dbuser:dbpasswd:host1,host2`.~~
+~~`mem` is an in-memory database intended for testing and takes no additional config options.~~  
+~~`mysql` is the MySQL database and accepts `username`, `password` and `host` arguments. Only `username` and `host` arguments are required. `port` is assumed to be 3306 unless otherwise specified.~~  
+~~`mongo` is MongoDB and accepts `username`, `password` and `host` arguments. All arguments are optional and multiple hosts can be specified using comma-separated values: `mongo:dbuser:dbpasswd:host1,host2`.~~  
 ~~`sqlite` is the SQLite database and accepts a `path` argument.~~
 
 ~~If no datastore is specified the `mem` store is used by default.~~
@@ -227,9 +227,9 @@ Supported options:
 - `permissions`: array of string. Specify the actions the certificate can perform. See the [`-O` option to `ssh-keygen(1)`](http://man.openbsd.org/OpenBSD-current/man1/ssh-keygen.1) for a complete list. e.g. `permissions = ["permit-pty", "permit-port-forwarding", force-command=/bin/ls", "source-address=192.168.0.0/24"]`
 
 ## aws
-AWS configuration is only needed for accessing signing keys stored on S3, and isn't totally necessary even then.
-The S3 client can be configured using any of [the usual AWS-SDK means](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk) - environment variables, IAM roles etc.
-It's strongly recommended that signing keys stored on S3 be locked down to specific IAM roles and encrypted using KMS.
+AWS configuration is only needed for accessing signing keys stored on S3, and isn't totally necessary even then.  
+The S3 client can be configured using any of [the usual AWS-SDK means](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk) - environment variables, IAM roles etc.  
+It's strongly recommended that signing keys stored on S3 be locked down to specific IAM roles and encrypted using KMS.  
 
 - `region`: string. AWS region the bucket resides in, e.g. `us-east-1`.
 - `access_key`: string. AWS Access Key ID. This can be a secret stored in a [vault](https://www.vaultproject.io/) using the form `/vault/path/key` e.g. `/vault/secret/cashier/aws_access_key`.
@@ -242,7 +242,7 @@ Vault support is currently a work-in-progress.
 - `token`: string. Auth token for the vault.
 
 # Usage
-Cashier comes in two parts, a [cli](cmd/cashier) and a [server](cmd/cashierd).
+Cashier comes in two parts, a [cli](cmd/cashier) and a [server](cmd/cashierd).  
 The server is configured using a HCL configuration file - [example](example-server.conf).
 
 For the server you need the following:
@@ -250,41 +250,33 @@ For the server you need the following:
 - OAuth (Google or GitHub) credentials. You may also need to set the callback URL when creating these.
 
 ## Using cashier
-Once the server is up and running you'll need to configure your client.
+Once the server is up and running you'll need to configure your client.  
 The client is configured using either a [HCL](https://github.com/hashicorp/hcl) configuration file - [example](example-client.conf) - or command-line flags.
 
-- `ca`          CA server (default "http://localhost:10000").
-- `config`      Path to config file (default "/Users/kevin/.cashier.conf").
-- `key_size`    Key size. Ignored for ed25519 keys (default 2048).
-- `key_type`    Type of private key to generate - rsa, ecdsa or ed25519 (default "rsa").
-- `public_file_prefix` Prefix for filename for public key and cert (optional, no default). The public key is put in a file with `.pub` appended to it; the public cert file in a file with `-cert.pub` appended to it.
-- `validity`    Key validity (default 24h0m0s).
+- `--ca`          CA server (default "http://localhost:10000").
+- `--config`      Path to config file (default "~/.cashier.conf").
+- `--key_size`    Key size. Ignored for ed25519 keys (default 2048).
+- `--key_type`    Type of private key to generate - rsa, ecdsa or ed25519 (default "rsa").
+- `--public_file_prefix` Prefix for filename for public key and cert (optional, no default). The public key is put in a file with `.pub` appended to it; the public cert file in a file with `-cert.pub` appended to it.
+- `--validity`    Key validity (default 24h).
 
 Running the `cashier` cli tool will open a browser window at the configured CA address.
-The CA will redirect to the auth provider for authorisation, and redirect back to the CA where the access token will printed.
-Copy the access token. In the terminal where you ran the `cashier` cli paste the token at the prompt.
-The client will then generate a new ssh key-pair and send the public part to the server (along with the access token).
+The CA will redirect to the auth provider for authorisation, and redirect back to the CA where the access token will printed.  
+Copy the access token. In the terminal where you ran the `cashier` cli paste the token at the prompt.  
+The client will then generate a new ssh key-pair and send the public part to the server (along with the access token).  
 Once signed the client will install the key and signed certificate in your ssh agent. When the certificate expires it will be removed automatically from the agent.
 
-If you set `public_file_prefix` then the public key and public cert
-will be written to the files that start with `public_file_prefix`
-and end with `.pub` and `-cert.pub` respectively.
+If you set `public_file_prefix` then the public key and public cert will be written to the files that start with `public_file_prefix` and end with `.pub` and `-cert.pub` respectively.
 
-In your `ssh_config` you can load these for a given host with the
-`IdentityFile` and `CertificateFile`. However prior to OpenSSH
-version 7.2p1 the latter option didn't exist. In that case you could
-specify `~/.ssh/some-identity` as your `IdentityFile` and OpenSSH
-would look in `~/.ssh/some-identity.pub` and
-`~/.ssh/some-identity-cert.pub`.
+In your `ssh_config` you can load these for a given host with the `IdentityFile` and `CertificateFile`. However prior to OpenSSH version 7.2p1 the latter option didn't exist.
+In that case you could specify `~/.ssh/some-identity` as your `IdentityFile` and OpenSSH would look in `~/.ssh/some-identity.pub` and `~/.ssh/some-identity-cert.pub`.
 
-Starting with 7.2p1 the two options exist in the `ssh_config` and
-you'll need to use the full paths to them. Note that like these
-`ssh_config` options, the `public_file_prefix` supports tilde
-expansion.
+Starting with 7.2p1 the two options exist in the `ssh_config` and you'll need to use the full paths to them.
+Note that like these `ssh_config` options, the `public_file_prefix` supports tilde expansion.
 
 ## Configuring SSH
-The ssh client needs no special configuration, just a running `ssh-agent`.
-The ssh server needs to trust the public part of the CA signing key. Add something like the following to your `sshd_config`:
+The ssh client needs no special configuration, just a running `ssh-agent`.  
+The ssh server needs to trust the public part of the CA signing key. Add something like the following to your `sshd_config`:  
 ```
 TrustedUserCAKeys /etc/ssh/ca.pub
 ```
@@ -293,12 +285,12 @@ where `/etc/ssh/ca.pub` contains the public part of your signing key.
 If you wish to use certificate revocation you need to set the `RevokedKeys` option in sshd_config - see the next section.
 
 ## Revoking certificates
-When a certificate is signed a record is kept in the configured datastore. You can view issued certs at `http(s)://<ca url>/admin/certs` and also revoke them.
+When a certificate is signed a record is kept in the configured datastore. You can view issued certs at `http(s)://<ca url>/admin/certs` and also revoke them.  
 The revocation list is served at `http(s)://<ca url>/revoked`. To use it your sshd_config must have `RevokedKeys` set:
 ```
 RevokedKeys /etc/ssh/revoked_keys
 ```
-See the [`RevokedKeys` option in the sshd_config man page](http://man.openbsd.org/OpenBSD-current/man5/sshd_config) for more.
+See the [`RevokedKeys` option in the sshd_config man page](http://man.openbsd.org/OpenBSD-current/man5/sshd_config) for more.  
 Keeping the revoked list up to date can be done with a cron job like:
 ```
 */10 * * * * * curl -s -o /etc/ssh/revoked_keys https://sshca.example.com/revoked
@@ -311,5 +303,5 @@ Remember that the `revoked_keys` file **must** exist and **must** be readable by
 - Host certificates - only user certificates are supported at present.
 
 # Contributing
-Pull requests are welcome but forking Go repos can be a pain. [This is a good guide to forking and creating pull requests for Go projects](https://splice.com/blog/contributing-open-source-git-repositories-go/).
+Pull requests are welcome but forking Go repos can be a pain. [This is a good guide to forking and creating pull requests for Go projects](https://splice.com/blog/contributing-open-source-git-repositories-go/).  
 Dependencies are vendored with [govendor](https://github.com/kardianos/govendor).

--- a/client/client.go
+++ b/client/client.go
@@ -3,8 +3,10 @@ package client
 import (
 	"bytes"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -15,6 +17,24 @@ import (
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 )
+
+// InstallPublicFiles installs the public part of the cert and key.
+func InstallPublicFiles(prefix string, cert *ssh.Certificate, pub ssh.PublicKey) error {
+	if prefix == "" {
+		return nil
+	}
+	pubKey := prefix + ".pub"
+	pubCert := prefix + "-cert.pub"
+	pubTxt := ssh.MarshalAuthorizedKey(pub)
+	certPubTxt := []byte(cert.Type() + " " + base64.StdEncoding.EncodeToString(cert.Marshal()))
+
+	if err := ioutil.WriteFile(pubKey, pubTxt, 0644); err != nil {
+		return err
+	}
+	err := ioutil.WriteFile(pubCert, certPubTxt, 0644)
+
+	return err
+}
 
 // InstallCert adds the private key and signed certificate to the ssh agent.
 func InstallCert(a agent.Agent, cert *ssh.Certificate, key Key) error {

--- a/client/client.go
+++ b/client/client.go
@@ -18,20 +18,18 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 )
 
-// InstallPublicFiles installs the public part of the cert and key.
-func InstallPublicFiles(prefix string, cert *ssh.Certificate, pub ssh.PublicKey) error {
+// SavePublicFiles installs the public part of the cert and key.
+func SavePublicFiles(prefix string, cert *ssh.Certificate, pub ssh.PublicKey) error {
 	if prefix == "" {
 		return nil
 	}
-	pubKey := prefix + ".pub"
-	pubCert := prefix + "-cert.pub"
 	pubTxt := ssh.MarshalAuthorizedKey(pub)
 	certPubTxt := []byte(cert.Type() + " " + base64.StdEncoding.EncodeToString(cert.Marshal()))
 
-	if err := ioutil.WriteFile(pubKey, pubTxt, 0644); err != nil {
+	if err := ioutil.WriteFile(prefix+".pub", pubTxt, 0644); err != nil {
 		return err
 	}
-	err := ioutil.WriteFile(pubCert, certPubTxt, 0644)
+	err := ioutil.WriteFile(prefix+"-cert.pub", certPubTxt, 0644)
 
 	return err
 }

--- a/client/config.go
+++ b/client/config.go
@@ -37,10 +37,10 @@ func ReadConfig(path string) (*Config, error) {
 	if err := viper.Unmarshal(c); err != nil {
 		return nil, err
 	}
-	if p, err := homedir.Expand(c.PublicFilePrefix); err != nil {
+	p, err := homedir.Expand(c.PublicFilePrefix)
+	if err != nil {
 		return nil, err
-	} else {
-		c.PublicFilePrefix = p
 	}
+	c.PublicFilePrefix = p
 	return c, nil
 }

--- a/client/config.go
+++ b/client/config.go
@@ -39,7 +39,8 @@ func ReadConfig(path string) (*Config, error) {
 	}
 	if p, err := homedir.Expand(c.PublicFilePrefix); err != nil {
 		return nil, err
+	} else {
+		c.PublicFilePrefix = p
 	}
-	c.PublicFilePrefix = p
 	return c, nil
 }

--- a/client/config.go
+++ b/client/config.go
@@ -3,6 +3,8 @@ package client
 import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"os/user"
+	"regexp"
 )
 
 // Config holds the client configuration.
@@ -12,6 +14,7 @@ type Config struct {
 	Keysize                int    `mapstructure:"key_size"`
 	Validity               string `mapstructure:"validity"`
 	ValidateTLSCertificate bool   `mapstructure:"validate_tls_certificate"`
+	PublicFilePrefix       string `mapstructure:"public_file_prefix"`
 }
 
 func setDefaults() {
@@ -19,7 +22,23 @@ func setDefaults() {
 	viper.BindPFlag("key_type", pflag.Lookup("key_type"))
 	viper.BindPFlag("key_size", pflag.Lookup("key_size"))
 	viper.BindPFlag("validity", pflag.Lookup("validity"))
+	viper.BindPFlag("public_file_prefix", pflag.Lookup("public_file_prefix"))
 	viper.SetDefault("validateTLSCertificate", true)
+}
+
+// expandTilde expands ~ and ~user for a given path.
+func expandTilde(path string) string {
+	re := regexp.MustCompile("^~([^/]*)(/.*)")
+	if m := re.FindStringSubmatch(path); len(m) > 0 {
+		u, _ := user.Current()
+		if m[1] != "" {
+			u, _ = user.Lookup(m[1])
+		}
+		if u != nil {
+			return u.HomeDir + m[2]
+		}
+	}
+	return path
 }
 
 // ReadConfig reads the client configuration from a file into a Config struct.
@@ -34,5 +53,6 @@ func ReadConfig(path string) (*Config, error) {
 	if err := viper.Unmarshal(c); err != nil {
 		return nil, err
 	}
+	c.PublicFilePrefix = expandTilde(c.PublicFilePrefix)
 	return c, nil
 }

--- a/cmd/cashier/main.go
+++ b/cmd/cashier/main.go
@@ -16,12 +16,13 @@ import (
 )
 
 var (
-	u, _     = user.Current()
-	cfg      = pflag.String("config", path.Join(u.HomeDir, ".cashier.conf"), "Path to config file")
-	ca       = pflag.String("ca", "http://localhost:10000", "CA server")
-	keysize  = pflag.Int("key_size", 2048, "Key size. Ignored for ed25519 keys")
-	validity = pflag.Duration("validity", time.Hour*24, "Key validity")
-	keytype  = pflag.String("key_type", "rsa", "Type of private key to generate - rsa, ecdsa or ed25519")
+	u, _             = user.Current()
+	cfg              = pflag.String("config", path.Join(u.HomeDir, ".cashier.conf"), "Path to config file")
+	ca               = pflag.String("ca", "http://localhost:10000", "CA server")
+	keysize          = pflag.Int("key_size", 2048, "Key size. Ignored for ed25519 keys")
+	validity         = pflag.Duration("validity", time.Hour*24, "Key validity")
+	keytype          = pflag.String("key_type", "rsa", "Type of private key to generate - rsa, ecdsa or ed25519")
+	publicFilePrefix = pflag.String("public_file_prefix", "", "Prefix for filename for public key and cert (optional, no default)")
 )
 
 func main() {
@@ -56,6 +57,9 @@ func main() {
 	defer sock.Close()
 	a := agent.NewClient(sock)
 	if err := client.InstallCert(a, cert, priv); err != nil {
+		log.Fatalln(err)
+	}
+	if err := client.InstallPublicFiles(c.PublicFilePrefix, cert, pub); err != nil {
 		log.Fatalln(err)
 	}
 	fmt.Println("Credentials added.")

--- a/cmd/cashier/main.go
+++ b/cmd/cashier/main.go
@@ -59,7 +59,7 @@ func main() {
 	if err := client.InstallCert(a, cert, priv); err != nil {
 		log.Fatalln(err)
 	}
-	if err := client.InstallPublicFiles(c.PublicFilePrefix, cert, pub); err != nil {
+	if err := client.SavePublicFiles(c.PublicFilePrefix, cert, pub); err != nil {
 		log.Fatalln(err)
 	}
 	fmt.Println("Credentials added.")


### PR DESCRIPTION
Allow the client to save the public key and public cert to files
that start with public_file_prefix and end with .pub and -cert.pub
respectively.

This is the naming scheme the ssh IdentityFile config option supported
for certs starting in version 5.4p1. Starting in version 7.2p1, an
additional option, CertificateFile, was added, but the IdentityFile-only
method with those names still works.

Used in conjunction with a user's ~/.ssh/config file setting
IdentitiesOnly and IdentityFile, this change will allow for multiple
ssh CAs for different services.

Note that this will resolve #49 .