### PR TITLE
Adding Gitlab groups as principals / Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM golang:1.7-alpine
 
 ADD . /go/src/github.com/nsheridan/cashier
-RUN apk add --update build-base
-RUN go install github.com/nsheridan/cashier/cmd/cashierd
+RUN apk --update add --virtual build-dependencies build-base && \
+    go install -ldflags="-s -w" github.com/nsheridan/cashier/cmd/cashierd && \
+    apk del build-dependencies && \
+    rm -rf /go/src
 
 VOLUME /cashier
 WORKDIR /cashier

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ server {
 }
 ```
 
-Prior to using MySQL or SQLite you need to create the database and tables using [the provided seed file](db/seed.sql).  
-e.g. `mysql < db/seed.sql`.  
+Prior to using MySQL or SQLite you need to create the database and tables using [the provided seed file](db/seed.sql).
+e.g. `mysql < db/seed.sql`.
 Obviously you should setup a role user for running in prodution.
 
 ## auth
@@ -184,6 +184,10 @@ Supported options:
 | Gitlab   | allusers | Allow all valid users to get signed keys. Only allowed if siteurl set. |
 | Gitlab   | group | If `allusers` and this are unset then you must whitelist individual users using `users_whitelist`. Otherwise the user must be a member of this group. |
 
+#### Notes on Gitlab auth provider
+
+The Gitlab auth provider tries to read a user's group memberships and add them to the certificate as principals. This is done independently from the options above.
+
 ## ssh
 - `signing_key`: string. Path to the signing ssh private key you created earlier. See the [note](#a-note-on-files) on files above.
 - `additional_principals`: array of string. By default certificates will have one principal set - the username portion of the requester's email address. If `additional_principals` is set, these will be added to the certificate e.g. if your production machines use shared user accounts.
@@ -191,9 +195,9 @@ Supported options:
 - `permissions`: array of string. Specify the actions the certificate can perform. See the [`-O` option to `ssh-keygen(1)`](http://man.openbsd.org/OpenBSD-current/man1/ssh-keygen.1) for a complete list. e.g. `permissions = ["permit-pty", "permit-port-forwarding", force-command=/bin/ls", "source-address=192.168.0.0/24"]`
 
 ## aws
-AWS configuration is only needed for accessing signing keys stored on S3, and isn't totally necessary even then.  
-The S3 client can be configured using any of [the usual AWS-SDK means](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk) - environment variables, IAM roles etc.  
-It's strongly recommended that signing keys stored on S3 be locked down to specific IAM roles and encrypted using KMS.  
+AWS configuration is only needed for accessing signing keys stored on S3, and isn't totally necessary even then.
+The S3 client can be configured using any of [the usual AWS-SDK means](https://github.com/aws/aws-sdk-go/wiki/configuring-sdk) - environment variables, IAM roles etc.
+It's strongly recommended that signing keys stored on S3 be locked down to specific IAM roles and encrypted using KMS.
 
 - `region`: string. AWS region the bucket resides in, e.g. `us-east-1`.
 - `access_key`: string. AWS Access Key ID. This can be a secret stored in a [vault](https://www.vaultproject.io/) using the form `/vault/path/key` e.g. `/vault/secret/cashier/aws_access_key`.
@@ -206,7 +210,7 @@ Vault support is currently a work-in-progress.
 - `token`: string. Auth token for the vault.
 
 # Usage
-Cashier comes in two parts, a [cli](cmd/cashier) and a [server](cmd/cashierd).  
+Cashier comes in two parts, a [cli](cmd/cashier) and a [server](cmd/cashierd).
 The server is configured using a HCL configuration file - [example](example-server.conf).
 
 For the server you need the following:
@@ -214,7 +218,7 @@ For the server you need the following:
 - OAuth (Google or GitHub) credentials. You may also need to set the callback URL when creating these.
 
 ## Using cashier
-Once the server is up and running you'll need to configure your client.  
+Once the server is up and running you'll need to configure your client.
 The client is configured using either a [HCL](https://github.com/hashicorp/hcl) configuration file - [example](example-client.conf) - or command-line flags.
 
 - `--ca`          CA server (default "http://localhost:10000").
@@ -225,9 +229,9 @@ The client is configured using either a [HCL](https://github.com/hashicorp/hcl) 
 - `--validity`    Key validity (default 24h).
 
 Running the `cashier` cli tool will open a browser window at the configured CA address.
-The CA will redirect to the auth provider for authorisation, and redirect back to the CA where the access token will printed.  
-Copy the access token. In the terminal where you ran the `cashier` cli paste the token at the prompt.  
-The client will then generate a new ssh key-pair and send the public part to the server (along with the access token).  
+The CA will redirect to the auth provider for authorisation, and redirect back to the CA where the access token will printed.
+Copy the access token. In the terminal where you ran the `cashier` cli paste the token at the prompt.
+The client will then generate a new ssh key-pair and send the public part to the server (along with the access token).
 Once signed the client will install the key and signed certificate in your ssh agent. When the certificate expires it will be removed automatically from the agent.
 
 If you set `key_file_prefix` then the public key and public cert will be written to the files that start with `key_file_prefix` and end with `.pub` and `-cert.pub` respectively.
@@ -239,8 +243,8 @@ Starting with 7.2p1 the two options exist in the `ssh_config` and you'll need to
 Note that like these `ssh_config` options, the `key_file_prefix` supports tilde expansion.
 
 ## Configuring SSH
-The ssh client needs no special configuration, just a running `ssh-agent`.  
-The ssh server needs to trust the public part of the CA signing key. Add something like the following to your `sshd_config`:  
+The ssh client needs no special configuration, just a running `ssh-agent`.
+The ssh server needs to trust the public part of the CA signing key. Add something like the following to your `sshd_config`:
 ```
 TrustedUserCAKeys /etc/ssh/ca.pub
 ```
@@ -249,12 +253,12 @@ where `/etc/ssh/ca.pub` contains the public part of your signing key.
 If you wish to use certificate revocation you need to set the `RevokedKeys` option in sshd_config - see the next section.
 
 ## Revoking certificates
-When a certificate is signed a record is kept in the configured database. You can view issued certs at `http(s)://<ca url>/admin/certs` and also revoke them.  
+When a certificate is signed a record is kept in the configured database. You can view issued certs at `http(s)://<ca url>/admin/certs` and also revoke them.
 The revocation list is served at `http(s)://<ca url>/revoked`. To use it your sshd_config must have `RevokedKeys` set:
 ```
 RevokedKeys /etc/ssh/revoked_keys
 ```
-See the [`RevokedKeys` option in the sshd_config man page](http://man.openbsd.org/OpenBSD-current/man5/sshd_config) for more.  
+See the [`RevokedKeys` option in the sshd_config man page](http://man.openbsd.org/OpenBSD-current/man5/sshd_config) for more.
 Keeping the revoked list up to date can be done with a cron job like:
 ```
 */10 * * * * * curl -s -o /etc/ssh/revoked_keys https://sshca.example.com/revoked
@@ -267,5 +271,5 @@ Remember that the `revoked_keys` file **must** exist and **must** be readable by
 - Host certificates - only user certificates are supported at present.
 
 # Contributing
-Pull requests are welcome but forking Go repos can be a pain. [This is a good guide to forking and creating pull requests for Go projects](https://splice.com/blog/contributing-open-source-git-repositories-go/).  
+Pull requests are welcome but forking Go repos can be a pain. [This is a good guide to forking and creating pull requests for Go projects](https://splice.com/blog/contributing-open-source-git-repositories-go/).
 Dependencies are vendored with [govendor](https://github.com/kardianos/govendor).

--- a/server/auth/github/github.go
+++ b/server/auth/github/github.go
@@ -96,6 +96,11 @@ func (c *Config) Revoke(token *oauth2.Token) error {
 	return nil
 }
 
+// TODO: Implement me
+func (c *Config) Principals(token *oauth2.Token) []string {
+	return []string{}
+}
+
 // StartSession retrieves an authentication endpoint from Github.
 func (c *Config) StartSession(state string) *auth.Session {
 	return &auth.Session{

--- a/server/auth/gitlab/gitlab.go
+++ b/server/auth/gitlab/gitlab.go
@@ -113,6 +113,25 @@ func (c *Config) Revoke(token *oauth2.Token) error {
 	return nil
 }
 
+// Adds a user's group memberships as principals
+func (c *Config) Principals(token *oauth2.Token) []string {
+	res := []string{}
+	if !token.Valid() {
+		return res
+	}
+	// Return the user's groups as principals
+	client := gitlabapi.NewOAuthClient(nil, token.AccessToken)
+	client.SetBaseURL(c.baseurl)
+	groups, _, err := client.Groups.SearchGroup(c.group)
+	if err != nil {
+		return res
+	}
+	for _, g := range groups {
+		res = append(res, g.Path)
+	}
+	return res
+}
+
 // StartSession retrieves an authentication endpoint from Gitlab.
 func (c *Config) StartSession(state string) *auth.Session {
 	return &auth.Session{

--- a/server/auth/google/google.go
+++ b/server/auth/google/google.go
@@ -102,6 +102,11 @@ func (c *Config) Revoke(token *oauth2.Token) error {
 	return err
 }
 
+// TODO: Implement me
+func (c *Config) Principals(token *oauth2.Token) []string {
+	return []string{}
+}
+
 // StartSession retrieves an authentication endpoint from Google.
 func (c *Config) StartSession(state string) *auth.Session {
 	return &auth.Session{

--- a/server/auth/provider.go
+++ b/server/auth/provider.go
@@ -8,6 +8,7 @@ type Provider interface {
 	StartSession(string) *Session
 	Exchange(string) (*oauth2.Token, error)
 	Username(*oauth2.Token) string
+	Principals(*oauth2.Token) []string
 	Valid(*oauth2.Token) bool
 	Revoke(*oauth2.Token) error
 }

--- a/server/auth/testprovider/testprovider.go
+++ b/server/auth/testprovider/testprovider.go
@@ -37,6 +37,11 @@ func (c *Config) Revoke(token *oauth2.Token) error {
 	return nil
 }
 
+// TODO: Implement me
+func (c *Config) Principals(token *oauth2.Token) []string {
+	return []string{}
+}
+
 // StartSession retrieves an authentication endpoint.
 func (c *Config) StartSession(state string) *auth.Session {
 	return &auth.Session{

--- a/server/signer/signer.go
+++ b/server/signer/signer.go
@@ -54,7 +54,7 @@ func (s *KeySigner) setPermissions(cert *ssh.Certificate) {
 }
 
 // SignUserKeyFromRPC returns a signed ssh certificate.
-func (s *KeySigner) SignUserKeyFromRPC(req *proto.SignRequest, username string) (*ssh.Certificate, error) {
+func (s *KeySigner) SignUserKeyFromRPC(req *proto.SignRequest, username string, principals []string) (*ssh.Certificate, error) {
 	valid, err := ptypes.Timestamp(req.GetValidUntil())
 	if err != nil {
 		return nil, err
@@ -63,11 +63,11 @@ func (s *KeySigner) SignUserKeyFromRPC(req *proto.SignRequest, username string) 
 		Key:        string(req.GetKey()),
 		ValidUntil: valid,
 	}
-	return s.SignUserKey(r, username)
+	return s.SignUserKey(r, username, principals)
 }
 
 // SignUserKey returns a signed ssh certificate.
-func (s *KeySigner) SignUserKey(req *lib.SignRequest, username string) (*ssh.Certificate, error) {
+func (s *KeySigner) SignUserKey(req *lib.SignRequest, username string, principals []string) (*ssh.Certificate, error) {
 	pubkey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(req.Key))
 	if err != nil {
 		return nil, err
@@ -85,6 +85,7 @@ func (s *KeySigner) SignUserKey(req *lib.SignRequest, username string) (*ssh.Cer
 		ValidPrincipals: []string{username},
 	}
 	cert.ValidPrincipals = append(cert.ValidPrincipals, s.principals...)
+	cert.ValidPrincipals = append(cert.ValidPrincipals, principals...)
 	s.setPermissions(cert)
 	if err := cert.SignCert(rand.Reader, s.ca); err != nil {
 		return nil, err

--- a/server/web.go
+++ b/server/web.go
@@ -141,8 +141,9 @@ func signHandler(a *appContext, w http.ResponseWriter, r *http.Request) (int, er
 		return http.StatusBadRequest, errors.Wrap(err, "unable to extract key from request")
 	}
 	username := authprovider.Username(token)
+	principals := authprovider.Principals(token)
 	authprovider.Revoke(token) // We don't need this anymore.
-	cert, err := keysigner.SignUserKey(req, username)
+	cert, err := keysigner.SignUserKey(req, username, principals)
 	if err != nil {
 		return http.StatusInternalServerError, errors.Wrap(err, "error signing key")
 	}


### PR DESCRIPTION
When setting cashier up, I thought back to [this post](https://code.facebook.com/posts/365787980419535/scalable-and-secure-access-with-ssh/) and about using Gitlab group membership as principals to map to usernames.

Sadly, this isn't supported but I'm guessing more people might want this. I've included and tested the implementation for gitlab, and added noop methods for the other providers.

Furthermore, I adjusted the Dockerfile to save a little space:
- Command go to create [smaller binaries ](https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/). I've tried using UPX too, but it's too much of a hassle as it isn't in Alpine stable yet.
- Merge several commands into a single RUN line creating fewer layers
- Purge build dependencies after build
- Remove sources